### PR TITLE
Update torrent.js: fix sort torrent files

### DIFF
--- a/src/interaction/torrent.js
+++ b/src/interaction/torrent.js
@@ -181,6 +181,11 @@ function install(){
 }
 
 function show(files){
+    files.sort((a, b)=>{
+        let an = a.path.replace(/\d+/g, (m) => m.length > 3 ? m : ('000' + m).substr(-4))
+        let bn = b.path.replace(/\d+/g, (m) => m.length > 3 ? m : ('000' + m).substr(-4))
+        return an.localeCompare(bn)
+    })
     let active   = Activity.active(),
         movie    = active.movie || SERVER.movie || {}
 


### PR DESCRIPTION
Исправлена сортировка файлов торрента, для правильной очерёдности сезонов и серий.

Поясняю что делает  регулярка, она тупо заменяет все цифры в строке (длинной до 3х символов) дополняя их нулями спереди до 4 цифр, те s1е1 или 1-1 или 1_1 и ep1 превращаются в s0001е0001 или 0001-0001 или 0001_0001 и ep0001 соответственно. Потом всё сортируется как строки (path при этом не изменяется).